### PR TITLE
Updated HRVSTDT (from VRI) to HARVEST_YEAR (from consolidated cutbloc…

### DIFF
--- a/R/calc_forest_age_class.R
+++ b/R/calc_forest_age_class.R
@@ -41,7 +41,8 @@ calc_forest_age_class <- function(vri_bem, most_recent_harvest_year) {
   setDT(vri_bem)
 
   # if proj_age_1 is empty the year of harvest date and most_recent_harvest_year to compute the projected age
-  vri_bem[is.na(PROJ_AGE_1), PROJ_AGE_1 := most_recent_harvest_year - year(as.Date(HRVSTDT, format = "%Y%m%d"))]
+  # the VRI layer (PROJ_AGE_1) is more out-of-date than the CCB (HARVEST_YEAR), so in all cases where HARVEST_YEAR is not NA, it should be used to calculate polygon age. When HARVEST_YEAR is NA, PROJ_AGE_1 should retain its initial value
+  vri_bem[!is.na(HARVEST_YEAR), PROJ_AGE_1 := most_recent_harvest_year - HARVEST_YEAR]
 
   # create variable for structural stage look up
   vri_bem[ , VRI_AGE_CL_STS := fcase(PROJ_AGE_1 < 0, -1,


### PR DESCRIPTION
…k layer--more up-to-date value). In cases where there are values for both PROJ_AGE_1 and HARVEST_YEAR, HARVEST_YEAR should get priority for calculating age